### PR TITLE
Fix faq linking to itself

### DIFF
--- a/src/content/docs/faq.mdx
+++ b/src/content/docs/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: Frequently Asked Questions
 section: Getting started
-order: 3
+order: 4
 ## TODO:
 ## - multiple files? no, in the future
 ---


### PR DESCRIPTION
The issue was caused by 2 documents (dev-tools.mdx and faq.mdx) having both the same order (managed manually at the moment). In the future a CI check should be used to check for duplicate section/order in documentation pages.